### PR TITLE
Add Biblix privacy policy to privacy pages

### DIFF
--- a/privacy/index-en.html
+++ b/privacy/index-en.html
@@ -46,6 +46,7 @@
       .i9fute { background-color: #f0f7ff; }
       .boottime { background-color: #f5f0ff; }
       .dinheiru { background-color: #fffbe6; }
+      .biblix { background-color: #e8fdf6; }
     </style>
   </head>
   <body>
@@ -66,6 +67,7 @@
       <li><a href="#i9fute">Privacy Policy – i9Fute</a></li>
       <li><a href="#boottime">Privacy Policy – Boot Time</a></li>
       <li><a href="#dinheiru">Privacy Policy – DinheirU</a></li>
+      <li><a href="#biblix">Privacy Policy – Biblix</a></li>
     </ul>
     <hr />
 
@@ -230,7 +232,247 @@
       </p>
     </div>
 
+    <!-- Biblix -->
+    <div class="policy-block biblix" id="biblix">
+      <h2>Privacy Policy – Biblix</h2>
+      <p><strong>Last update:</strong> September 22, 2025</p>
+
+      <h3>Summary</h3>
+      <ul>
+        <li>
+          We collect Firebase account identifiers (UID, email, name, optional
+          photo), quiz progress (levels, score, coins, achievements), usage events
+          and ad identifiers provided by the device.
+        </li>
+        <li>
+          We use this data to authenticate you, sync your progress, provide
+          limited personalization, improve quality through metrics and telemetry,
+          send relevant notifications and monetize the app with ads.
+        </li>
+        <li>
+          We share data only with essential providers such as Google Firebase,
+          Google Sign-In and Google Mobile Ads (AdMob), following their policies.
+        </li>
+        <li>
+          You may exercise rights of access, correction, portability, withdrawal
+          of consent and others under the LGPD, GDPR and CCPA.
+        </li>
+        <li>
+          Request deletion or portability via
+          <a href="mailto:arnaldo.araujo.dev@gmail.com"
+            >arnaldo.araujo.dev@gmail.com</a
+          >; removal may erase progress, levels, coins and achievements.
+        </li>
+      </ul>
+
+      <h3>1. Information we collect</h3>
+      <p>We collect the following data when you use Biblix:</p>
+      <ul>
+        <li>
+          <strong>Account data:</strong> Firebase UID, email address, name and an
+          optional profile photo provided by you or through Google Sign-In.
+        </li>
+        <li>
+          <strong>Progress data:</strong> current level, score, coins, unlocked
+          achievements and history of quizzes taken.
+        </li>
+        <li>
+          <strong>Usage events and telemetry:</strong> interactions with quizzes,
+          screens accessed, timestamps, performance metrics and crashes logged by
+          Firebase Analytics.
+        </li>
+        <li>
+          <strong>Identifiers and notifications:</strong> Firebase Cloud
+          Messaging tokens, device identifiers and advertising IDs provided by the
+          operating system.
+        </li>
+        <li>
+          <strong>Technical metadata:</strong> device model, operating system,
+          language and logs needed for support and fraud prevention.
+        </li>
+      </ul>
+      <p>
+        We do not intentionally collect sensitive information and ask that you do
+        not send data beyond what is necessary.
+      </p>
+
+      <h3>2. How we use the information</h3>
+      <p>We use your data to:</p>
+      <ul>
+        <li>
+          Authenticate your account via email/password or Google Sign-In through
+          Firebase Auth.
+        </li>
+        <li>
+          Save and sync progress, levels, coins and achievements in Cloud
+          Firestore.
+        </li>
+        <li>
+          Provide limited personalization (for example, recommending quizzes based
+          on your progress) and keep your profile up to date.
+        </li>
+        <li>
+          Measure performance, detect errors and understand usage metrics through
+          Firebase Analytics.
+        </li>
+        <li>
+          Send notifications about new quizzes, reminders or bonuses via Firebase
+          Cloud Messaging.
+        </li>
+        <li>
+          Display and measure ads from Google Mobile Ads (AdMob) to sustain
+          monetization.
+        </li>
+      </ul>
+
+      <h3>3. Legal bases under the LGPD, GDPR and CCPA</h3>
+      <p>
+        Depending on your location and interaction with the app, we process
+        personal data based on:
+      </p>
+      <ul>
+        <li>
+          <strong>Consent:</strong> for notifications, personalized ads when
+          applicable and the use of advertising identifiers.
+        </li>
+        <li>
+          <strong>Performance of a contract:</strong> to provide Biblix,
+          authenticate you, maintain your progress and record achievements.
+        </li>
+        <li>
+          <strong>Legitimate interest:</strong> to improve the app, prevent fraud,
+          ensure security and measure essential metrics without harming your
+          rights.
+        </li>
+        <li>
+          <strong>Legal obligations:</strong> to respond to requests from
+          authorities or comply with applicable laws, including consumer rights.
+        </li>
+      </ul>
+      <p>
+        You can revoke consent at any time without affecting the lawfulness of
+        prior processing.
+      </p>
+
+      <h3>4. Sharing with third parties</h3>
+      <p>We share your data only with:</p>
+      <ul>
+        <li>
+          <strong>Google Firebase</strong> (Firebase Authentication, Cloud
+          Firestore, Firebase Analytics, Firebase Cloud Messaging) – see the
+          <a href="https://firebase.google.com/support/privacy" target="_blank"
+            >Firebase Privacy Policy</a
+          >.
+        </li>
+        <li>
+          <strong>Google</strong> (Google Sign-In and Google Mobile Ads/AdMob) –
+          see the
+          <a href="https://policies.google.com/privacy" target="_blank"
+            >Google Privacy Policy</a
+          >.
+        </li>
+        <li>
+          <strong>Technical support and infrastructure providers</strong>
+          contracted to operate Biblix under confidentiality obligations.
+        </li>
+      </ul>
+      <p>
+        We may also share aggregated or anonymized data, without identifying you,
+        for reporting and analytics.
+      </p>
+
+      <h3>5. Data retention and deletion</h3>
+      <p>
+        We retain your data while your account remains active and for up to 24
+        months after the last interaction for backup, accounting and legal
+        obligations. Event logs and advertising identifiers are kept for as long
+        as needed for usage analysis, usually up to 13 months or as allowed by the
+        platforms. You may request deletion, anonymization or portability by
+        emailing
+        <a href="mailto:arnaldo.araujo.dev@gmail.com"
+          >arnaldo.araujo.dev@gmail.com</a
+        >. After confirming your identity, we will delete or export the data
+        within a reasonable time and inform you of impacts such as permanent loss
+        of progress, levels, coins and achievements.
+      </p>
+
+      <h3>6. Children and minors</h3>
+      <p>
+        Biblix is not directed to children and we do not knowingly collect data
+        from individuals under 13 (or the equivalent age under local law) without
+        verifiable parental consent. If you believe a minor has provided data
+        without authorization, contact us at
+        <a href="mailto:arnaldo.araujo.dev@gmail.com"
+          >arnaldo.araujo.dev@gmail.com</a
+        > to request removal or blocking.
+      </p>
+
+      <h3>7. Security</h3>
+      <p>
+        We apply reasonable measures such as secure authentication, encryption in
+        transit (HTTPS/TLS), access controls and anomaly monitoring within Google
+        Firebase services. Despite our efforts, no storage or transmission method
+        is 100% secure; we recommend keeping your credentials confidential and
+        updating your devices regularly.
+      </p>
+
+      <h3>8. Your rights</h3>
+      <p>Depending on the jurisdiction, you have the right to:</p>
+      <ul>
+        <li>Confirm whether we process your data and access copies.</li>
+        <li>Correct incomplete, inaccurate or outdated data.</li>
+        <li>
+          Request deletion, anonymization or blocking of unnecessary or excessive
+          data.
+        </li>
+        <li>
+          Request portability to another provider when technically feasible.
+        </li>
+        <li>
+          Withdraw consent or opt out of sharing data with third parties for
+          advertising purposes under the CCPA.
+        </li>
+        <li>
+          Object to processing based on legitimate interest and request review of
+          relevant automated decisions.
+        </li>
+      </ul>
+      <p>
+        To exercise any right, send your request to
+        <a href="mailto:arnaldo.araujo.dev@gmail.com"
+          >arnaldo.araujo.dev@gmail.com</a
+        >. We may ask for additional information to confirm your identity before
+        responding.
+      </p>
+
+      <h3>9. International transfers</h3>
+      <p>
+        Google Firebase and Google services may process and store your data in
+        data centers located outside your country of residence. We use standard
+        contractual safeguards, technical controls and policies aligned with the
+        LGPD, GDPR and CCPA requirements to protect your data during international
+        transfers.
+      </p>
+
+      <h3>10. Changes to this policy</h3>
+      <p>
+        We may update this Privacy Policy to reflect changes in Biblix or in
+        legal requirements. When relevant changes occur, we will notify you within
+        the app, by email or through another appropriate method before the new
+        version takes effect. The “Last update” date will be adjusted accordingly.
+      </p>
+
+      <h3>11. Contact</h3>
+      <p>
+        For questions, requests or complaints related to privacy, write to
+        <a href="mailto:arnaldo.araujo.dev@gmail.com"
+          >arnaldo.araujo.dev@gmail.com</a
+        >. We will respond within a reasonable time and work to resolve your
+        inquiries.
+      </p>
+    </div>
+
     <hr />
-    <p><strong>Last update:</strong> August 21, 2025</p>
+    <p><strong>Last update:</strong> September 22, 2025</p>
   </body>
 </html>

--- a/privacy/index.html
+++ b/privacy/index.html
@@ -46,6 +46,7 @@
       .i9fute { background-color: #f0f7ff; }
       .boottime { background-color: #f5f0ff; }
       .dinheiru { background-color: #fffbe6; }
+      .biblix { background-color: #e8fdf6; }
     </style>
   </head>
   <body>
@@ -67,6 +68,7 @@
       <li><a href="#i9fute">Política de Privacidade – i9Fute</a></li>
       <li><a href="#boottime">Política de Privacidade – Boot Time</a></li>
       <li><a href="#dinheiru">Política de Privacidade – DinheirU</a></li>
+      <li><a href="#biblix">Política de Privacidade – Biblix</a></li>
     </ul>
     <hr />
 
@@ -240,7 +242,259 @@
       </p>
     </div>
 
+    <!-- Biblix -->
+    <div class="policy-block biblix" id="biblix">
+      <h2>Política de Privacidade – Biblix</h2>
+      <p><strong>Última atualização:</strong> 22/09/2025</p>
+
+      <h3>Resumo</h3>
+      <ul>
+        <li>
+          Coletamos identificadores de conta do Firebase (UID, e-mail, nome, foto
+          opcional), progresso em quizzes (níveis, pontuação, coins, conquistas),
+          eventos de uso e identificadores de anúncios fornecidos pelo dispositivo.
+        </li>
+        <li>
+          Usamos esses dados para autenticar você, sincronizar seu progresso,
+          personalizar de forma limitada, aprimorar a qualidade com métricas e
+          telemetria, enviar notificações relevantes e monetizar o app com
+          anúncios.
+        </li>
+        <li>
+          Compartilhamos dados apenas com provedores essenciais como Google
+          Firebase, Google Sign-In e Google Mobile Ads (AdMob), seguindo suas
+          políticas.
+        </li>
+        <li>
+          Você pode exercer direitos de acesso, correção, portabilidade,
+          revogação de consentimento e outros previstos na LGPD, GDPR e CCPA.
+        </li>
+        <li>
+          Solicite exclusão ou portabilidade pelo e-mail
+          <a href="mailto:arnaldo.araujo.dev@gmail.com"
+            >arnaldo.araujo.dev@gmail.com</a
+          >; a remoção pode apagar progresso, níveis, coins e conquistas.
+        </li>
+      </ul>
+
+      <h3>1. Informações que coletamos</h3>
+      <p>Coletamos os seguintes dados quando você usa o Biblix:</p>
+      <ul>
+        <li>
+          <strong>Dados de conta:</strong> UID do Firebase, endereço de e-mail,
+          nome e foto de perfil opcional fornecidos por você ou pelo Google
+          Sign-In.
+        </li>
+        <li>
+          <strong>Dados de progresso:</strong> nível atual, pontuação, moedas
+          (“coins”), conquistas desbloqueadas e histórico de quizzes respondidos.
+        </li>
+        <li>
+          <strong>Eventos de uso e telemetria:</strong> interações com quizzes,
+          telas acessadas, carimbos de data/hora, métricas de desempenho e falhas
+          registradas pelo Firebase Analytics.
+        </li>
+        <li>
+          <strong>Identificadores e notificações:</strong> tokens de Firebase
+          Cloud Messaging, identificadores de dispositivo e IDs de publicidade
+          fornecidos pelo sistema operacional.
+        </li>
+        <li>
+          <strong>Metadados técnicos:</strong> modelo do dispositivo, sistema
+          operacional, idioma e logs necessários para suporte e prevenção de
+          fraudes.
+        </li>
+      </ul>
+      <p>
+        Não coletamos intencionalmente informações sensíveis e solicitamos que
+        você não envie dados além do necessário.
+      </p>
+
+      <h3>2. Como usamos as informações</h3>
+      <p>Utilizamos seus dados para:</p>
+      <ul>
+        <li>
+          Autenticar sua conta por e-mail/senha ou Google Sign-In via Firebase
+          Auth.
+        </li>
+        <li>
+          Salvar e sincronizar progresso, níveis, moedas e conquistas no Cloud
+          Firestore.
+        </li>
+        <li>
+          Personalizar de forma limitada a experiência (por exemplo, recomendar
+          quizzes com base no seu progresso) e manter seu perfil atualizado.
+        </li>
+        <li>
+          Medir desempenho, detectar erros e entender métricas de uso por meio do
+          Firebase Analytics.
+        </li>
+        <li>
+          Enviar notificações sobre novos quizzes, lembretes ou bônus via
+          Firebase Cloud Messaging.
+        </li>
+        <li>
+          Exibir e mensurar anúncios do Google Mobile Ads (AdMob) para sustentar
+          a monetização.
+        </li>
+      </ul>
+
+      <h3>3. Bases legais sob a LGPD, GDPR e CCPA</h3>
+      <p>
+        Dependendo da sua localização e da interação com o app, tratamos dados
+        pessoais com base em:
+      </p>
+      <ul>
+        <li>
+          <strong>Consentimento:</strong> para notificações, anúncios
+          personalizados quando aplicável e uso de identificadores de
+          publicidade.
+        </li>
+        <li>
+          <strong>Execução de contrato:</strong> para fornecer o Biblix,
+          autenticar, manter seu progresso e registrar conquistas.
+        </li>
+        <li>
+          <strong>Legítimo interesse:</strong> para melhorar o app, prevenir
+          fraude, garantir segurança e medir métricas essenciais, sem prejudicar
+          seus direitos.
+        </li>
+        <li>
+          <strong>Obrigações legais:</strong> para responder a solicitações de
+          autoridades ou cumprir leis aplicáveis, inclusive direitos do
+          consumidor.
+        </li>
+      </ul>
+      <p>
+        Você pode revogar o consentimento a qualquer momento, sem afetar a
+        legalidade do tratamento anterior.
+      </p>
+
+      <h3>4. Compartilhamento com terceiros</h3>
+      <p>Compartilhamos seus dados apenas com:</p>
+      <ul>
+        <li>
+          <strong>Google Firebase</strong> (Firebase Authentication, Cloud
+          Firestore, Firebase Analytics, Firebase Cloud Messaging) – consulte a
+          <a href="https://firebase.google.com/support/privacy" target="_blank"
+            >Política do Firebase</a
+          >.
+        </li>
+        <li>
+          <strong>Google</strong> (Google Sign-In e Google Mobile Ads/AdMob) –
+          consulte a
+          <a href="https://policies.google.com/privacy" target="_blank"
+            >Política do Google</a
+          >.
+        </li>
+        <li>
+          <strong>Prestadores de suporte técnico e infraestrutura</strong>
+          contratados para operar o Biblix, sob obrigações contratuais de
+          confidencialidade.
+        </li>
+      </ul>
+      <p>
+        Também podemos compartilhar dados agregados ou anonimizados, sem
+        identificar você, para relatórios e análises.
+      </p>
+
+      <h3>5. Retenção e exclusão de dados</h3>
+      <p>
+        Mantemos seus dados enquanto sua conta permanecer ativa e por até 24
+        meses após a última interação para fins de backup, contabilidade e
+        obrigações legais. Logs de eventos e identificadores de publicidade são
+        retidos pelo tempo necessário para análises de uso, geralmente por até 13
+        meses ou conforme permitido pelas plataformas. Você pode solicitar
+        exclusão, anonimização ou portabilidade enviando um e-mail para
+        <a href="mailto:arnaldo.araujo.dev@gmail.com"
+          >arnaldo.araujo.dev@gmail.com</a
+        >. Após confirmação de identidade, excluiremos ou exportaremos os dados
+        dentro de um prazo razoável, informando impactos como perda permanente de
+        progresso, níveis, moedas e conquistas.
+      </p>
+
+      <h3>6. Crianças e menores</h3>
+      <p>
+        O Biblix não é direcionado a crianças e não coletamos conscientemente
+        dados de menores de 13 anos (ou idade equivalente conforme legislação
+        local) sem consentimento verificável de pais ou responsáveis. Se você
+        acredita que um menor nos forneceu dados sem autorização, entre em
+        contato pelo e-mail
+        <a href="mailto:arnaldo.araujo.dev@gmail.com"
+          >arnaldo.araujo.dev@gmail.com</a
+        > para solicitar remoção ou bloqueio.
+      </p>
+
+      <h3>7. Segurança</h3>
+      <p>
+        Aplicamos medidas razoáveis como autenticação segura, criptografia em
+        trânsito (HTTPS/TLS), controles de acesso e monitoramento de anomalias
+        nos serviços do Google Firebase. Apesar dos esforços, nenhum método de
+        armazenamento ou transmissão é 100% seguro; recomendamos que você
+        mantenha suas credenciais em sigilo e atualize seus dispositivos
+        regularmente.
+      </p>
+
+      <h3>8. Seus direitos</h3>
+      <p>Dependendo da jurisdição, você tem direito de:</p>
+      <ul>
+        <li>Confirmar se tratamos seus dados e acessar cópias.</li>
+        <li>Corrigir dados incompletos, inexatos ou desatualizados.</li>
+        <li>
+          Solicitar exclusão, anonimização ou bloqueio de dados desnecessários ou
+          excessivos.
+        </li>
+        <li>
+          Solicitar portabilidade para outro fornecedor, quando tecnicamente
+          viável.
+        </li>
+        <li>
+          Revogar consentimento ou optar por não compartilhar dados com
+          terceiros para fins de publicidade conforme o CCPA.
+        </li>
+        <li>
+          Opor-se ao tratamento com base em legítimo interesse e solicitar revisão
+          de decisões automatizadas relevantes.
+        </li>
+      </ul>
+      <p>
+        Para exercer qualquer direito, envie sua solicitação para
+        <a href="mailto:arnaldo.araujo.dev@gmail.com"
+          >arnaldo.araujo.dev@gmail.com</a
+        >. Poderemos pedir informações adicionais para confirmar sua identidade
+        antes de responder.
+      </p>
+
+      <h3>9. Transferências internacionais</h3>
+      <p>
+        Os serviços do Google Firebase e do Google podem processar e armazenar
+        seus dados em centros de dados localizados fora do seu país de residência.
+        Utilizamos salvaguardas contratuais padrão, controles técnicos e
+        políticas alinhadas às exigências da LGPD, GDPR e CCPA para proteger seus
+        dados em transferências internacionais.
+      </p>
+
+      <h3>10. Alterações desta política</h3>
+      <p>
+        Podemos atualizar esta Política de Privacidade para refletir mudanças no
+        Biblix ou em requisitos legais. Quando houver alterações relevantes,
+        avisaremos dentro do aplicativo, por e-mail ou por outro meio apropriado
+        antes que a nova versão produza efeitos. A data de “Última atualização”
+        será ajustada para refletir a vigência.
+      </p>
+
+      <h3>11. Contato</h3>
+      <p>
+        Para perguntas, solicitações ou reclamações relacionadas a privacidade,
+        escreva para
+        <a href="mailto:arnaldo.araujo.dev@gmail.com"
+          >arnaldo.araujo.dev@gmail.com</a
+        >. Responderemos dentro de um prazo razoável e buscaremos solucionar suas
+        dúvidas.
+      </p>
+    </div>
+
     <hr />
-    <p><strong>Última atualização:</strong> 21/08/2025</p>
+    <p><strong>Última atualização:</strong> 22/09/2025</p>
   </body>
 </html>


### PR DESCRIPTION
## Summary
- add a new Biblix policy section to the Portuguese privacy page, including navigation link and updated last-update date
- translate and add the same Biblix policy to the English privacy page, keeping both versions aligned
